### PR TITLE
fix: replace expired domain with Netlify URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <a href="https://metrohrms.site">
+    <a href="https://metrohrms.netlify.app">
   <img src="client/public/metro.png" width="128px" />
     </a>
     <h1><i>AI-Driven Human Resource Management ⚡</i></h1>
@@ -16,7 +16,7 @@
 
 </div>
 
-***Self-hosted Version*** : [_click here_](https://metrohrms.site)
+***Self-hosted Version*** : [_click here_](https://metrohrms.netlify.app)
 
 ***Installation Guide*** : [_click here_](https://github.com/WhatsWrongOB/AI-HRMS/blob/main/INSTALLATION.md)
 

--- a/client/index.html
+++ b/client/index.html
@@ -17,11 +17,11 @@
   <meta property="og:title" content="Metro HR ⚡">
   <meta property="og:description"
     content="AI-Driven HRMS to optimize employee data management, performance tracking, leave management, and recruitment with AI-powered features.">
-  <meta property="og:image" content="https://metrohrms.site/hrms.png">
-  <meta property="og:url" content="https://metrohrms.site">
+  <meta property="og:image" content="https://metrohrms.netlify.app/hrms.png">
+  <meta property="og:url" content="https://metrohrms.netlify.app">
   <meta property="og:type" content="website">
 
-  <link rel="canonical" href="https://metrohrms.site">
+  <link rel="canonical" href="https://metrohrms.netlify.app">
   <link href="https://fonts.googleapis.com/css2?family=Bruno+Ace&display=swap" rel="stylesheet">
 
   <title>Metro HR</title>

--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -1,13 +1,7 @@
 [[redirects]]
-  from = "https://metrohrms.netlify.app/*"
-  to = "https://metrohrms.site/:splat"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to = "/index.html"
+status = 200
 
 [build]
-  image = "ubuntu-22.04"
+image = "ubuntu-22.04"

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow: /private/
-Sitemap: https://metrohrms.site/sitemap.xml
+Sitemap: https://metrohrms.netlify.app/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
   <url>
-    <loc>https://metrohrms.site/</loc>
+    <loc>https://metrohrms.netlify.app/</loc>
     <lastmod>2025-08-04</lastmod>
     <priority>1.00</priority>
   </url>
 
   <url>
-    <loc>https://metrohrms.site/careers</loc>
+    <loc>https://metrohrms.netlify.app/careers</loc>
     <lastmod>2025-08-04</lastmod>
     <priority>0.80</priority>
   </url>


### PR DESCRIPTION
## Description

Replaces the expired `metrohrms.site` domain with the project's Netlify domain.

### Changes

* Removed the redirect from the Netlify domain to the expired custom domain.
* Updated the README deployment link.
* Updated Open Graph and canonical URLs.
* Updated `robots.txt` and `sitemap.xml`.

### Testing

* Verified there are no remaining references to `metrohrms.site`.
* Ran `npm install` successfully.
* Attempted `npm run build`, but the build currently fails because of an existing Tailwind configuration issue in `tailwind.config.js`.
* Confirmed the same Tailwind configuration exists on the original `main` branch, so the build issue is unrelated to this PR.
